### PR TITLE
Quick fix for no interfaces

### DIFF
--- a/producers/juniper_conf/juniper_conf.py
+++ b/producers/juniper_conf/juniper_conf.py
@@ -120,6 +120,8 @@ def main():
             interfaces = junosRemote.show_interfaces()
             if interfaces:
                 physical_interfaces = get_physical_interfaces(interfaces)
+            else:
+                physical_interfaces = []
 
             hardware = junosRemote.show_hardware()
             if hardware:


### PR DESCRIPTION
Had a failure in juniper producer today. It was due to no configured interfaces. This should fix that by defaulting to empty list.
